### PR TITLE
feat(helm): expose K8ssandra native Prometheus telemetry via values

### DIFF
--- a/deploy/helm/examon/templates/k8ssandra-cluster.yaml
+++ b/deploy/helm/examon/templates/k8ssandra-cluster.yaml
@@ -36,6 +36,15 @@ spec:
         racks:
           {{- toYaml .Values.cassandra.datacenters.dc1.racks | nindent 10 }}
         {{- end }}
+        {{- with .Values.cassandra.telemetry }}
+        telemetry:
+          prometheus:
+            enabled: {{ .prometheus.enabled | default false }}
+            {{- with .prometheus.commonLabels }}
+            commonLabels:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+        {{- end }}
   {{- if .Values.cassandra.reaper }}
   reaper:
     autoScheduling:


### PR DESCRIPTION
Add opt-in `cassandra.telemetry.prometheus` block to the K8ssandraCluster template so users can enable the native ServiceMonitor generated by the K8ssandra Operator without maintaining a separate manifest.

When `cassandra.telemetry.prometheus.enabled: true`, the operator creates a ServiceMonitor automatically. The block is guarded by `{{- with }}` so existing deployments that omit the key are unaffected (retrocompatible).

Example values:
  cassandra:
    telemetry:
      prometheus:
        enabled: true
        commonLabels:
          release: prometheus  # match kube-prometheus-stack selector